### PR TITLE
Pom modified to add charset

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>ru.netology</groupId>
-    <artifactId>MoneyManager2</artifactId>
+    <artifactId>MoneyManager</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>
@@ -27,5 +27,17 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.12.4</version>
+                <configuration>
+                    <failIfNoTests>true</failIfNoTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>
@@ -36,6 +37,7 @@
                 <version>2.22.2</version>
                 <configuration>
                     <failIfNoTests>true</failIfNoTests>
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.7.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.7.0</version>
         </dependency>
     </dependencies>
 
@@ -32,7 +32,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.4</version>
+                <version>2.22.2</version>
                 <configuration>
                     <failIfNoTests>true</failIfNoTests>
                 </configuration>


### PR DESCRIPTION
При запуске тестов непосредственно из SummatorTest.java тесты выполнялись положительно. При запуске тестов на панели Maven тесты проходили с ошибкой. Выяснилось, что при выполнении тестов из панели Maven есть проблемы с кодировкой. При выводе в консоль одной записи непосредственно из SummatorTest.java получали нормальный текст:
{шапка=одежда, акции=финансы, сухарики=еда, курица=еда, тапки=одежда, булка=еда, колбаса=еда, мыло=быт}
При выводе этой же строки при запуске тестов из панели Maven получали:
{РєСѓСЂРёС†Р°=РµРґР°, С‚Р°РїРєРё=РѕРґРµР¶РґР°, РјС‹Р»Рѕ=Р±С‹С‚, Р°РєС†РёРё=С„РёРЅР°РЅСЃС‹, РєРѕР»Р±Р°СЃР°=РµРґР°, С€Р°РїРєР°=РѕРґРµР¶РґР°, Р±СѓР»РєР°=РµРґР°, СЃСѓС…Р°СЂРёРєРё=РµРґР°}

Помогло добавление в pom.xml строки 
`<argLine>-Dfile.encoding=UTF-8</argLine>`


```
<plugins>
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-surefire-plugin</artifactId>
                <version>2.22.2</version>
                <configuration>
                    <failIfNoTests>true</failIfNoTests>
                    <argLine>-Dfile.encoding=UTF-8</argLine>
                </configuration>
            </plugin>
        </plugins>
```